### PR TITLE
Remove Journal Export function

### DIFF
--- a/infocenter/gtk/window.blp
+++ b/infocenter/gtk/window.blp
@@ -215,11 +215,6 @@ template $Window: Adw.ApplicationWindow {
 menu primary_menu {
   section {
     item {
-      label: _("Export Journal…");
-      action: 'app.journal';
-    }
-
-    item {
       label: _("About Information Center");
       action: 'app.about';
     }

--- a/infocenter/main.py
+++ b/infocenter/main.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-from gettext import gettext as _
 from pathlib import Path
-import infocenter.system_check as system_check
 import sys
 import gi
 
@@ -26,7 +24,6 @@ class Application(Adw.Application):
         self.autostart = False
         self.create_action("quit", lambda *_: self.quit(), ["<primary>q"])
         self.create_action("about", self.on_about_action)
-        self.create_action("journal", self.on_journal_action)
         self.add_main_option(
             "autostart",
             ord("a"),
@@ -59,25 +56,6 @@ class Application(Adw.Application):
             win = Window(application=self)
 
         win.present()
-
-    def on_journal_action(self, widget, _unused):
-        """
-        Action for journal export in menu button
-        """
-        dialog = Gtk.FileDialog(
-            accept_label="Export",
-            title=_("Export Journal to File"),
-            initial_name="journal.txt",
-            modal=True,
-        )
-
-        def response(dialog, result):
-            if result.had_error():
-                return
-            filepath = Path(dialog.save_finish(result).get_path())
-            system_check.write_journal(filepath)
-
-        dialog.save(parent=self.props.active_window, callback=response)
 
     def on_about_action(self, widget, _):
         """Invoked when we click "about" in the main menu."""

--- a/infocenter/system_check.py
+++ b/infocenter/system_check.py
@@ -76,10 +76,3 @@ def check_vpn() -> bool:
         return any(i in names for i in ("gpd0", "vpn0", "tun0"))
     except ValueError:
         return False
-
-
-def write_journal(path: str) -> None:
-    journal = subprocess.Popen(["journalctl", "-b"], stdout=subprocess.PIPE)
-    (result, err) = journal.communicate()
-    with open(path, mode="w") as file:
-        file.write(result.decode("utf-8"))


### PR DESCRIPTION
Due to system restrictions it is no longer allowed on our clients and in order to switch to Flatpak distribution this call is also useless. Let's remove it.